### PR TITLE
로드 반복 호출 시 음식 카드 중복 해결 (#9)

### DIFF
--- a/Tteokbokki/Assets/02.Script/Manager/PackagingAreaManager.cs
+++ b/Tteokbokki/Assets/02.Script/Manager/PackagingAreaManager.cs
@@ -63,6 +63,11 @@ public class PackagingAreaManager : MonoBehaviour
             Destroy(food.gameObject);
         }
         currentFoods.Clear();
+
+        foreach (var slot in slots)
+        {
+            slot.ClearStackedFoods();
+        }
     }
 
     public void RemoveFoodFromAllSlots(CookedFoodUI food)
@@ -91,6 +96,8 @@ public class PackagingAreaManager : MonoBehaviour
 
         return result;
     }
+
+
     public void RestoreSlots(List<List<Dictionary<string, int>>> savedData)
     {
         ClearAllFoods(); // 기존 음식들 제거

--- a/Tteokbokki/Assets/02.Script/PackagingSlot.cs
+++ b/Tteokbokki/Assets/02.Script/PackagingSlot.cs
@@ -159,6 +159,18 @@ public class PackagingSlot : MonoBehaviour, IDropHandler
         food.currentSlot = this;
     }
 
+    public void ClearStackedFoods()
+    {
+        foreach (var food in stackedFoods)
+        {
+            if (food != null)
+            {
+                Destroy(food.gameObject);
+            }
+        }
+        stackedFoods.Clear();
+    }
+
     public bool IsTopOfStack(CookedFoodUI food)
     {
         return stackedFoods.Count > 0 && stackedFoods[stackedFoods.Count - 1] == food;

--- a/Tteokbokki/Assets/02.Script/StoveSlot.cs
+++ b/Tteokbokki/Assets/02.Script/StoveSlot.cs
@@ -36,6 +36,8 @@ public class StoveSlot : MonoBehaviour, IPointerClickHandler, IPointerEnterHandl
     public bool IsCooked => isCooked;
     public float GetCookTimeRemaining() => cookTimeRemaining;
 
+    private GameObject spawnedFood;
+
     public void Initialize(StoveManager manager)
     {
         stoveManager = manager;
@@ -89,10 +91,16 @@ public class StoveSlot : MonoBehaviour, IPointerClickHandler, IPointerEnterHandl
         isCooked = true;
         timerText.text = "완료!";
 
-        GameObject obj = Instantiate(cookedFoodPrefab, cookedFoodSpawnPoint);
-        obj.transform.localPosition = Vector3.zero;
+        if (spawnedFood != null)  // 혹시 이전 음식이 있다면 제거
+        {
+            Destroy(spawnedFood);
+            spawnedFood = null;
+        }
 
-        var foodUI = obj.GetComponent<CookedFoodUI>();
+        spawnedFood = Instantiate(cookedFoodPrefab, cookedFoodSpawnPoint);  // 여기!
+        spawnedFood.transform.localPosition = Vector3.zero;
+
+        var foodUI = spawnedFood.GetComponent<CookedFoodUI>();
         foodUI.Initialize(currentIngredients);
 
         // 툴팁 연결
@@ -119,6 +127,14 @@ public class StoveSlot : MonoBehaviour, IPointerClickHandler, IPointerEnterHandl
         wokIcon.SetActive(false);
         timerText.text = "대기중";  // 필요 시 텍스트 갱신
         SetSelected(false);         // 선택 하이라이트 해제
+
+        // spawnedFood가 아직 화구 위에 있을 때만 파괴
+        if (spawnedFood != null && spawnedFood.transform.parent == cookedFoodSpawnPoint)
+        {
+            Destroy(spawnedFood);
+        }
+
+        spawnedFood = null;
     }
 
     public Dictionary<string, int> GetCookedIngredients() => isCooked ? currentIngredients : null;
@@ -152,16 +168,20 @@ public class StoveSlot : MonoBehaviour, IPointerClickHandler, IPointerEnterHandl
 
         if (data.isCooked)
         {
+            if (spawnedFood != null)
+            {
+                Destroy(spawnedFood);
+            }
             // 조리 완료 상태만 복원 (음식 생성)
             currentIngredients = new Dictionary<string, int>(data.currentIngredients);
             isCooked = true;
             isCooking = false;
             timerText.text = "완료!";
 
-            GameObject obj = Instantiate(cookedFoodPrefab, cookedFoodSpawnPoint);
-            obj.transform.localPosition = Vector3.zero;
+            spawnedFood = Instantiate(cookedFoodPrefab, cookedFoodSpawnPoint);
+            spawnedFood.transform.localPosition = Vector3.zero;
 
-            var foodUI = obj.GetComponent<CookedFoodUI>();
+            var foodUI = spawnedFood.GetComponent<CookedFoodUI>();
             foodUI.Initialize(currentIngredients);
             foodUI.originStoveSlot = this;
         }


### PR DESCRIPTION
# Pull Request 제목
로드 반복 호출 시 음식 카드 중복 해결 (#9)

## 관련 이슈
Closes #9 

## 변경 사항 요약
- 로드 반복 호출 시 포장대 슬롯 위 음식카드가 중복해서 나타나는 현상 수정
- `` 화구 위 조리된 음식카드가 중복해서 나타나는 현상 수정
- `` 예기치 않게 음식카드가 Destroy 되는 현상 수정

## 테스트 방법
- [ ] 빌드가 정상적으로 되는지 확인
- [ ] 해당 기능이 예상대로 동작하는지 확인
- [ ] 기존 기능이 영향을 받지 않는지 확인

## 변경된 파일
- PackagingAreaManager.cs
- PackagingSlot.cs
- StoveSlot.cs

## 스크린샷 / 결과 (옵션)
- 직접 보시겠습니다.

## 리뷰어에게
- 스크립트를 꽤 건들였는데... 미처 말씀을 못드렸...?

---

_이 PR은 기능 단위로 잘게 나뉜 작업 중 하나입니다. main/dev 브랜치에 병합 후, 관련 이슈는 자동으로 종료됩니다._
