### PR TITLE
feat: 특정 재료 포함 조리 성공 시 보너스 #16

### DIFF
--- a/Tteokbokki/Assets/01.Scenes/SampleScene.unity
+++ b/Tteokbokki/Assets/01.Scenes/SampleScene.unity
@@ -13961,6 +13961,51 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1334658495}
   m_CullTransparentMesh: 1
+--- !u!1 &1359252037
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1359252039}
+  - component: {fileID: 1359252038}
+  m_Layer: 0
+  m_Name: DailyBonusManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1359252038
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1359252037}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 76892e084d24fc84087790ed96f47bbe, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  bonusText: {fileID: 1416694765}
+--- !u!4 &1359252039
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1359252037}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.36047, y: 0.35858, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1367417711
 GameObject:
   m_ObjectHideFlags: 0
@@ -14720,6 +14765,7 @@ RectTransform:
   - {fileID: 1423018174}
   - {fileID: 181349028}
   - {fileID: 975442194}
+  - {fileID: 1416694764}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -14727,6 +14773,142 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
+--- !u!1 &1416694763
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1416694764}
+  - component: {fileID: 1416694766}
+  - component: {fileID: 1416694765}
+  m_Layer: 5
+  m_Name: Text_Bonus
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1416694764
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1416694763}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1415978089}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -311.83, y: 38}
+  m_SizeDelta: {x: 740.33, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1416694765
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1416694763}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: New Text
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 757b89fca16bf2a42aea52c077897b62, type: 2}
+  m_sharedMaterial: {fileID: -952747375617257926, guid: 757b89fca16bf2a42aea52c077897b62, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4278190080
+  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1416694766
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1416694763}
+  m_CullTransparentMesh: 1
 --- !u!1 &1423018173
 GameObject:
   m_ObjectHideFlags: 0
@@ -23353,3 +23535,4 @@ SceneRoots:
   - {fileID: 1227901671}
   - {fileID: 177007826}
   - {fileID: 371865953}
+  - {fileID: 1359252039}

--- a/Tteokbokki/Assets/02.Script/Manager/DailyBonusManager.cs
+++ b/Tteokbokki/Assets/02.Script/Manager/DailyBonusManager.cs
@@ -1,0 +1,97 @@
+using System.Collections.Generic;
+using System.Linq;
+using TMPro;
+using UnityEngine;
+
+public class DailyBonusManager : MonoBehaviour
+{
+    public static DailyBonusManager Instance { get; private set; }
+
+    private HashSet<string> todayBonusIngredients = new();    // 오늘 적용 중인 보너스 재료
+    private HashSet<string> tomorrowBonusCandidates = new();  // 마감 시 보여줄 내일 보너스 재료
+
+    private const int bonusPerIngredient = 5000; // 1개 포함당 보너스 금액
+
+    public TextMeshProUGUI bonusText;
+
+    [SerializeField]
+    private static readonly HashSet<string> excludedBonusIngredients = new()
+{
+    "떡",
+    "오뎅",
+    "파",
+    "양배추",
+    "군자 소스",
+};
+
+    private void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+        Instance = this;
+    }
+
+    private void Update()
+    {
+        GetTomorrowBonusText();
+    }
+
+    public void SetTomorrowBonusIngredients()
+    {
+        tomorrowBonusCandidates = PickRandomIngredients(2);  // 랜덤 2종 선택
+        Debug.Log($"[보너스] 내일 보너스 재료 예정: {string.Join(", ", tomorrowBonusCandidates)}");
+    }
+
+    public void ApplyNewDayBonus()
+    {
+        todayBonusIngredients = new HashSet<string>(tomorrowBonusCandidates);
+        Debug.Log($"[보너스] 오늘 보너스 재료 적용됨: {string.Join(", ", todayBonusIngredients)}");
+    }
+
+    public int CalculateBonusFromIngredients(Dictionary<string, int> ingredients)
+    {
+        if (ingredients == null || todayBonusIngredients.Count == 0)
+            return 0;
+
+        int totalBonus = 0;
+        foreach (var kv in ingredients)
+        {
+            if (todayBonusIngredients.Contains(kv.Key))
+            {
+                totalBonus += bonusPerIngredient * kv.Value;
+            }
+        }
+
+        return totalBonus;
+    }
+
+    public string GetTomorrowBonusText()
+    {
+        if (tomorrowBonusCandidates.Count == 0)
+            return "예정된 보너스 재료 없음";
+
+        bonusText.text = "내일의 보너스 재료: " + string.Join(", ", tomorrowBonusCandidates);
+
+        return "내일의 보너스 재료: " + string.Join(", ", tomorrowBonusCandidates);
+    }
+
+    private HashSet<string> PickRandomIngredients(int count)
+    {
+        var eligible = IngredientEconomyDatabase.Data.Keys
+            .Where(name => !excludedBonusIngredients.Contains(name)) // 제외 대상 제거
+            .ToList();
+
+        var result = new HashSet<string>();
+        while (result.Count < count && eligible.Count > 0)
+        {
+            int idx = UnityEngine.Random.Range(0, eligible.Count);
+            result.Add(eligible[idx]);
+            eligible.RemoveAt(idx);
+        }
+
+        return result;
+    }
+}

--- a/Tteokbokki/Assets/02.Script/Manager/DailyBonusManager.cs.meta
+++ b/Tteokbokki/Assets/02.Script/Manager/DailyBonusManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 76892e084d24fc84087790ed96f47bbe

--- a/Tteokbokki/Assets/02.Script/PackagingSlot.cs
+++ b/Tteokbokki/Assets/02.Script/PackagingSlot.cs
@@ -94,7 +94,20 @@ public class PackagingSlot : MonoBehaviour, IDropHandler
         else
         {
             ReceiptLineManager.Instance.RecordSuccessfulReceipt(receipt);
-            PlayerWalletManager.Instance.AddIncome(receipt.GetTotalPrice());
+
+            int baseIncome = receipt.GetTotalPrice();
+            int bonus = 0;
+
+            foreach (var dish in cookedIngredients)
+            {
+                bonus += DailyBonusManager.Instance.CalculateBonusFromIngredients(dish);
+            }
+
+            int totalIncome = baseIncome + bonus;
+
+            PlayerWalletManager.Instance.AddIncome(totalIncome);
+            if (bonus > 0)
+                Debug.Log($"[보너스] {bonus:N0}원 보너스 지급 (보너스 재료 포함)");
         }
 
         TooltipManager.Hide(TooltipType.Info); // 툴팁 숨기기


### PR DESCRIPTION
# Pull Request 제목
feat: 특정 재료 포함 조리 성공 시 보너스 #16

## 관련 이슈
Closes #16 

## 변경 사항 요약
- 내일의 보너스 재료를 포함해서 조리 성공 시 보너스 금액이 수익으로 들어옴

## 테스트 방법
- [ ] 빌드가 정상적으로 되는지 확인
- [ ] 해당 기능이 예상대로 동작하는지 확인
- [ ] 기존 기능이 영향을 받지 않는지 확인

## 변경된 파일
- SampleScene.unity
- DailyBonusManager.cs
- PackagingSlot.cs

## 리뷰어에게
- GameManager의 EndOfDay에 
```
DailyBonusManager.Instance.SetTomorrowBonusIngredients();
DailyBonusManager.Instance.ApplyNewDayBonus();
```
- 추가해야 제대로 돌아갑니다~

---

_이 PR은 기능 단위로 잘게 나뉜 작업 중 하나입니다. main/dev 브랜치에 병합 후, 관련 이슈는 자동으로 종료됩니다._
