### PR TITLE
feat: 날짜 요일 EndOfDay StartOfDay 수정 #20

### DIFF
--- a/Tteokbokki/Assets/01.Scenes/SampleScene.unity
+++ b/Tteokbokki/Assets/01.Scenes/SampleScene.unity
@@ -385,6 +385,142 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 32396523}
   m_CullTransparentMesh: 1
+--- !u!1 &34114575
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 34114576}
+  - component: {fileID: 34114578}
+  - component: {fileID: 34114577}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &34114576
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 34114575}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1721469116}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &34114577
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 34114575}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: "\uD558\uB8E8 \uC2DC\uC791"
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8decb252f5f00a443a0d5f7d8224e5d7, type: 2}
+  m_sharedMaterial: {fileID: 4362109639005920471, guid: 8decb252f5f00a443a0d5f7d8224e5d7, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4281479730
+  m_fontColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 20
+  m_fontSizeBase: 20
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &34114578
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 34114575}
+  m_CullTransparentMesh: 1
 --- !u!1 &43560378
 GameObject:
   m_ObjectHideFlags: 0
@@ -1657,8 +1793,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   attemptInterval: 0.8
-  baseOrderProbability: 0.03
-  previousDaySuccessRate: 1
+  baseOrderProbability: 0.1
+  previousDaySuccessRate: 0.5
   generator: {fileID: 8846668}
   delayRangeSeconds: {x: 0.5, y: 2}
 --- !u!4 &177007826
@@ -9947,9 +10083,9 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 1985912284}
-        m_TargetAssemblyTypeName: GameManager, Assembly-CSharp
-        m_MethodName: EndOfDay
+      - m_Target: {fileID: 1950824749}
+        m_TargetAssemblyTypeName: GameClock, Assembly-CSharp
+        m_MethodName: SetToEightFiftyNine
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -14040,8 +14176,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -66, y: 460}
-  m_SizeDelta: {x: 200, y: 50}
+  m_AnchoredPosition: {x: -71.23, y: 435.69995}
+  m_SizeDelta: {x: 217.34, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1367417713
 MonoBehaviour:
@@ -14747,6 +14883,7 @@ RectTransform:
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 1543458370}
   - {fileID: 1950824746}
   - {fileID: 476810737}
   - {fileID: 423450649}
@@ -14757,6 +14894,7 @@ RectTransform:
   - {fileID: 1436988763}
   - {fileID: 1443096711}
   - {fileID: 1123651206}
+  - {fileID: 1721469116}
   - {fileID: 144850647}
   - {fileID: 1441614454}
   - {fileID: 1367417712}
@@ -15941,6 +16079,142 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1543458369
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1543458370}
+  - component: {fileID: 1543458373}
+  - component: {fileID: 1543458372}
+  m_Layer: 5
+  m_Name: Text_Date
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1543458370
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1543458369}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1415978089}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 888.77, y: -49}
+  m_SizeDelta: {x: 217.34, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1543458372
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1543458369}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: "\uB0A0\uC9DC"
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8decb252f5f00a443a0d5f7d8224e5d7, type: 2}
+  m_sharedMaterial: {fileID: 4362109639005920471, guid: 8decb252f5f00a443a0d5f7d8224e5d7, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4278190080
+  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 21
+  m_fontSizeBase: 21
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1543458373
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1543458369}
+  m_CullTransparentMesh: 1
 --- !u!1 &1557926913
 GameObject:
   m_ObjectHideFlags: 0
@@ -17856,6 +18130,139 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1705586206}
   m_CullTransparentMesh: 1
+--- !u!1 &1721469115
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1721469116}
+  - component: {fileID: 1721469119}
+  - component: {fileID: 1721469118}
+  - component: {fileID: 1721469117}
+  m_Layer: 5
+  m_Name: Button_StartOfDay
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1721469116
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1721469115}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 34114576}
+  m_Father: {fileID: 1415978089}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -359, y: -272}
+  m_SizeDelta: {x: 99.97, y: 49.997}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1721469117
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1721469115}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1721469118}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1985912284}
+        m_TargetAssemblyTypeName: GameManager, Assembly-CSharp
+        m_MethodName: StartOfDay
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &1721469118
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1721469115}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1721469119
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1721469115}
+  m_CullTransparentMesh: 1
 --- !u!1 &1749337166
 GameObject:
   m_ObjectHideFlags: 0
@@ -19109,8 +19516,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 82, y: -71}
-  m_SizeDelta: {x: 93.59, y: 50}
+  m_AnchoredPosition: {x: 90.007996, y: -67.29999}
+  m_SizeDelta: {x: 158.4, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1950824747
 MonoBehaviour:
@@ -19159,8 +19566,8 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 36
-  m_fontSizeBase: 36
+  m_fontSize: 30
+  m_fontSizeBase: 30
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
@@ -19224,9 +19631,11 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   clockText: {fileID: 1950824747}
+  dateText: {fileID: 1543458372}
+  realSecondsPerGameMinute: 2
   startYear: 2025
-  startMonth: 6
-  startDay: 29
+  startMonth: 7
+  startDay: 4
   startHour: 12
   startMinute: 0
 --- !u!1 &1962174480
@@ -19686,7 +20095,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b74d2d0d4fe6f2f43966fe9380a63001, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  receiptLineManager: {fileID: 1436988764}
 --- !u!4 &1985912285
 Transform:
   m_ObjectHideFlags: 0

--- a/Tteokbokki/Assets/02.Script/GameClock.cs
+++ b/Tteokbokki/Assets/02.Script/GameClock.cs
@@ -1,10 +1,28 @@
 using System;
 using UnityEngine;
 using TMPro;
+using System.Data;
+using System.IO;
+
+[Serializable]
+public class DateWrapper
+{
+    public string dateString;
+}
 
 public class GameClock : MonoBehaviour
 {
+    public static GameClock Instance { get; private set; }
     public TextMeshProUGUI clockText; // UI TextMeshPro 요소 연결
+    public TextMeshProUGUI dateText;
+    public float realSecondsPerGameMinute = 2f; // 현실 3초 = 게임 1분
+
+    [Header("영업 시간")]
+    public static int openingHour = 12;
+    public static int closingHour = 21;
+
+    public static bool isPaused = false;
+    private bool hasReachedClosingTime = false;
 
     [Header("초기 날짜 및 시간 설정")]
     public int startYear = 2025;
@@ -14,31 +32,114 @@ public class GameClock : MonoBehaviour
     public int startMinute = 0;
 
     public static DateTime gameTime;
-    private float elapsedTime = 0f;
-    private const float realSecondsPerGameMinute = 2f; // 현실 3초 = 게임 1분
     public DateTime GetCurrentGameTime() => gameTime;
+    // 마지막 플레이 날짜 저장 경로
+    private const string LastDateFileName = "LastPlayedDate.json";
     private void Awake()
     {
         gameTime = new DateTime(startYear, startMonth, startDay, startHour, startMinute, 0);
+
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+        Instance = this;
     }
     void Start()
     {
-        
+        UpdateTimeAndDateDisplay();
     }
 
     void Update()
     {
-        elapsedTime += Time.deltaTime;
-        if (elapsedTime >= realSecondsPerGameMinute)
+        if (!isPaused)
         {
-            gameTime = gameTime.AddMinutes(1); // 게임 내 1분 증가
-            elapsedTime = 0f;
+            AdvanceTime(Time.deltaTime);
         }
+    }
 
-        clockText.text = gameTime.ToString("HH:mm"); // UI 업데이트 (초 제외)
+    public void AdvanceTime(float realSecondsElapsed)
+    {
+        if (isPaused) return;
+
+        float gameMinutesToAdd = realSecondsElapsed / realSecondsPerGameMinute;
+        gameTime = gameTime.AddMinutes(gameMinutesToAdd);
+        clockText.text = gameTime.ToString("HH:mm");
+
+        // 마감 시간 도달 감지
+        if (!hasReachedClosingTime && gameTime.Hour >= closingHour)
+        {
+            hasReachedClosingTime = true;
+            GameManager.Instance.OnClosingTimeReached();
+        }
+    }
+
+    public static void Pause()
+    {
+        isPaused = true;
+    }
+
+    public static void Resume()
+    {
+        isPaused = false;
     }
     public static void SetGameTime(DateTime newTime)
     {
         gameTime = newTime;
     }
+    public void SetToStartOfDay()
+    {
+        // 날짜는 유지하고 시간만 12시로 설정
+        DateTime dateOnly = gameTime.Date;
+        gameTime = dateOnly.AddHours(openingHour);
+
+        hasReachedClosingTime = false;
+
+        UpdateTimeAndDateDisplay();
+    }
+
+    public void SetToEightFiftyNine()
+    {
+        DateTime dateOnly = gameTime.Date;
+        gameTime = dateOnly.AddHours(20).AddMinutes(59);  // 오후 8시 59분
+
+        Debug.Log($"[DEBUG] 게임 시간이 오후 8시 59분으로 설정됨: {gameTime:yyyy-MM-dd HH:mm}");
+
+        UpdateTimeAndDateDisplay();
+    }
+    public void UpdateTimeAndDateDisplay()
+    {
+        DateTime gameTime = GameClock.gameTime;
+        string[] koreanDays = { "일", "월", "화", "수", "목", "금", "토" };
+        string formatted = $"{gameTime:yyyy년 M월 d일} ({koreanDays[(int)gameTime.DayOfWeek]})";
+
+        if (dateText != null)
+            dateText.text = formatted;
+        if (clockText != null)
+            clockText.text = gameTime.ToString("HH:mm");
+    }
+    public static void SaveLastPlayedDate(DateTime date)
+    {
+        string json = JsonUtility.ToJson(new DateWrapper { dateString = date.ToString("yyyy-MM-dd") });
+        File.WriteAllText(Path.Combine(Application.persistentDataPath, LastDateFileName), json);
+    }
+
+    public static DateTime? LoadLastPlayedDate()
+    {
+        string fullPath = Path.Combine(Application.persistentDataPath, LastDateFileName);
+        if (!File.Exists(fullPath))
+            return null;
+
+        string json = File.ReadAllText(fullPath);
+        DateWrapper wrapper = JsonUtility.FromJson<DateWrapper>(json);
+
+        if (DateTime.TryParse(wrapper.dateString, out DateTime result))
+        {
+            return result;
+        }
+
+        return null;
+    }
+
 }

--- a/Tteokbokki/Assets/02.Script/Manager/GameManager.cs
+++ b/Tteokbokki/Assets/02.Script/Manager/GameManager.cs
@@ -1,16 +1,20 @@
 using System;
+using System.Collections;
 using System.Linq;
 using UnityEngine;
 
 public class GameManager : MonoBehaviour
 {
-    public ReceiptLineManager receiptLineManager;
-
-
+    public static GameManager Instance { get; private set; }
     // Start is called once before the first execution of Update after the MonoBehaviour is created
     void Start()
     {
-        
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+        Instance = this;
     }
 
     // Update is called once per frame
@@ -21,13 +25,28 @@ public class GameManager : MonoBehaviour
 
     public void StartOfDay()
     {
-        // 하루 시작 시 초기화
-        receiptLineManager.ClearMissedReceipts();
-        receiptLineManager.ClearSuccessfulReceipts();
+        GameClock.gameTime = GameClock.gameTime.AddDays(1);
+        GameClock.Instance.SetToStartOfDay();
+        GameClock.Instance.UpdateTimeAndDateDisplay();
 
         IngredientStockManager.Instance.ResetDailyOrderFlags();
-
         IngredientStockManager.Instance.AdvanceDayAndDecay();
+
+        StoveManager.Instance.ClearAllStoves(); // 조리 상태 초기화 (필요 시)
+        PackagingAreaManager.Instance.ClearAllFoods(); // 포장대 초기화
+        PlayerWokManager.Instance.ClearWok(); // 플레이어 웍 초기화
+        ReceiptLineManager.Instance.ClearAllReceipts(); // 영수증 리스트 초기화
+        ReceiptLineManager.Instance.ClearMissedReceipts(); // 실패 영수증 리스트 초기화
+        ReceiptLineManager.Instance.ClearSuccessfulReceipts(); // 성공 영수증 리스트 초기화
+
+        ReceiptSystem.CurrentReceiptID = 1; // 주문 번호 초기화
+        ReceiptSystem.CurrentOrderItemID = 1; // 메뉴 번호 초기화
+
+        DailyBonusManager.Instance.ApplyNewDayBonus();
+
+        GameClock.Resume();
+
+        OrderSpawner.Instance.RestartSpawning();
 
         // 로그 출력
         Debug.Log("[시작] 새로운 영업일이 시작되었습니다.");
@@ -35,8 +54,13 @@ public class GameManager : MonoBehaviour
 
     public void EndOfDay()
     {
-        var missed = receiptLineManager.GetMissedReceipts();
-        var successful = receiptLineManager.GetSuccessfulReceipts();
+        GameClock.Pause();
+        OrderSpawner.Instance.StopSpawning();
+
+        PackagingAreaManager.Instance.ClearAllFoods();
+
+        var missed = ReceiptLineManager.Instance.GetMissedReceipts();
+        var successful = ReceiptLineManager.Instance.GetSuccessfulReceipts();
         DateTime today = GameClock.gameTime.Date;
 
         ReceiptManager.SaveMissedReceipts(missed, today);
@@ -44,23 +68,59 @@ public class GameManager : MonoBehaviour
 
         // 판매 총액 계산
         int successTotal = successful.Sum(r => r.GetTotalPrice());
-        int missedTotal = missed.Sum(r => r.GetOrders().Sum(o => o.TotalPrice));
-
         // 세금 차감
         PlayerWalletManager.Instance.DeductDailyTaxes(successTotal);
+        // 손실 총액 계산
+        int missedTotal = missed.Sum(r => r.GetOrders().Sum(o => o.TotalPrice));
+        // 성공률 계산
+        float successRate = successful.Count / (float)(successful.Count + missed.Count + 0.01f);
+        OrderSpawner.Instance.SetPreviousDaySuccessRate(successRate); // 다음날 확률 반영용
 
         // 로그 출력
         Debug.Log($"[마감] 성공 주문 {successful.Count}건 / 총 판매금액: {successTotal:N0}원");
         Debug.Log($"[마감] 미완료 주문 {missed.Count}건 / 손실 금액: {missedTotal:N0}원");
         Debug.Log($"[마감] 세금 {Mathf.RoundToInt(successTotal * PlayerWalletManager.Instance.taxRate):N0}원 납부");
 
-        // 초기화
-        receiptLineManager.ClearMissedReceipts();
-        receiptLineManager.ClearSuccessfulReceipts(); // 성공 기록도 초기화!
-
         IngredientStockManager.Instance.ResetDailyOrderFlags();
 
-        IngredientStockManager.Instance.AdvanceDayAndDecay();
-        Debug.Log("[마감] 영업일이 종료되었습니다. 재고가 초기화되고 유통기한이 갱신되었습니다.");
+        IngredientStockManager.Instance.UpdateLowStockList();
+        Debug.Log(IngredientStockManager.Instance.GetLowStockText());
+
+        DailyBonusManager.Instance.SetTomorrowBonusIngredients();
+
+        GameSaveManager.Instance.DeleteSaveFile();
+
+        GameClock.SaveLastPlayedDate(today);
     }
+    public void OnClosingTimeReached()
+    {
+        OrderSpawner.Instance.StopSpawning(); // 주문 생성 중단
+
+        // 남은 영수증이 없다면 바로 마감
+        if (ReceiptLineManager.Instance.GetReceiptSlots().Count == 0)
+        {
+            EndOfDay();
+        }
+        else
+        {
+            // 감시 루틴 시작
+            StartCoroutine(WaitForReceiptClearAndEnd());
+        }
+    }
+    private IEnumerator WaitForReceiptClearAndEnd()
+    {
+        Debug.Log("[마감 대기] 오후 9시 이후, 영수증 처리 완료 대기 중...");
+
+        // 매 0.5초마다 확인
+        while (ReceiptLineManager.Instance.GetReceiptSlots().Count > 0)
+        {
+            yield return new WaitForSeconds(0.5f);
+        }
+
+        Debug.Log("[마감] 모든 영수증 처리 완료. EndOfDay 호출!");
+
+        EndOfDay();
+    }
+
+
 }

--- a/Tteokbokki/Assets/02.Script/Manager/GameSaveManager.cs
+++ b/Tteokbokki/Assets/02.Script/Manager/GameSaveManager.cs
@@ -34,8 +34,19 @@ public class StoveSlotSaveData
 
 public class GameSaveManager : MonoBehaviour
 {
+    public static GameSaveManager Instance { get; private set; }
     private const string SaveFilePath = "SaveData.json";
 
+
+    private void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+        Instance = this;
+    }
     public void SaveGame()
     {
         GameSaveData data = new GameSaveData
@@ -104,6 +115,21 @@ public class GameSaveManager : MonoBehaviour
         ReceiptLineManager.Instance.RestorePendingReceipts(data.pendingReceipts);
 
         Debug.Log("게임 불러오기 완료!");
+    }
+
+    public void DeleteSaveFile()
+    {
+        string fullPath = Path.Combine(Application.persistentDataPath, "SaveData.json");
+
+        if (File.Exists(fullPath))
+        {
+            File.Delete(fullPath);
+            Debug.Log("[저장] 하루 종료로 인해 기존 SaveData.json 삭제됨");
+        }
+        else
+        {
+            Debug.Log("[저장] 삭제할 SaveData.json이 존재하지 않습니다.");
+        }
     }
 
     public void OnSaveButtonPressed()

--- a/Tteokbokki/Assets/02.Script/Manager/IngredientStockManager.cs
+++ b/Tteokbokki/Assets/02.Script/Manager/IngredientStockManager.cs
@@ -275,6 +275,15 @@ public class IngredientStockManager : MonoBehaviour
         }
         return result;
     }
+    public int GetPurchasedIngredientCount()
+    {
+        return purchasedAtLeastOnce.Count;
+    }
+
+    public bool HasPurchasedBefore(string ingredientName)
+    {
+        return purchasedAtLeastOnce.Contains(ingredientName);
+    }
 
     public void AdvanceDayAndDecay()
     {

--- a/Tteokbokki/Assets/02.Script/Manager/StoveManager.cs
+++ b/Tteokbokki/Assets/02.Script/Manager/StoveManager.cs
@@ -155,6 +155,24 @@ public class StoveManager : MonoBehaviour
         }
         return true;
     }
+    public void ClearAllStoves()
+    {
+        if (stoves == null || stoves.Length == 0)
+        {
+            Debug.LogWarning("[StoveManager] 스토브 슬롯이 없습니다.");
+            return;
+        }
+
+        foreach (var slot in stoves)
+        {
+            if (slot != null)
+            {
+                slot.ResetSlot();
+            }
+        }
+
+        Debug.Log("[StoveManager] 모든 화구 상태 초기화 완료");
+    }
 }
 
 

--- a/Tteokbokki/Assets/02.Script/OrderSpawner.cs
+++ b/Tteokbokki/Assets/02.Script/OrderSpawner.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 
 public class OrderSpawner : MonoBehaviour
 {
+    public static OrderSpawner Instance { get; private set; }
     [Header("기본 설정")]
     [Tooltip("주문 생성 시도 주기 (초)")]
     public float attemptInterval = 0.5f;
@@ -14,13 +15,24 @@ public class OrderSpawner : MonoBehaviour
 
     [Tooltip("전날 성공률 (GameManager에서 설정)")]
     [Range(0f, 1f)]
-    public float previousDaySuccessRate = 1.0f;
+    public float previousDaySuccessRate = 0.5f;
+    public void SetPreviousDaySuccessRate(float successRate) => previousDaySuccessRate = successRate;
 
     [Tooltip("영수증 생성기 연결")]
     public RandomReceiptGenerator generator;
 
     [Tooltip("생성 시 딜레이 범위 (초)")]
     public Vector2 delayRangeSeconds = new Vector2(0.5f, 2.0f);
+
+    private void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+        Instance = this;
+    }
 
     private void Start()
     {
@@ -48,11 +60,13 @@ public class OrderSpawner : MonoBehaviour
 
     private float CalculateCurrentOrderProbability()
     {
-        float performanceFactor = Mathf.Clamp(previousDaySuccessRate * 1.2f, 0.3f, 1.0f);
+        float performanceFactor = Mathf.Clamp(previousDaySuccessRate * 1.2f, 0.3f, 0.8f);
         float timeFactor = GetTimeBuzzFactor(GameClock.gameTime.Hour);
         float dayFactor = GetWeekdayBuzzFactor(GameClock.gameTime.DayOfWeek);
 
-        return baseOrderProbability * performanceFactor * timeFactor * dayFactor;
+        float diversityFactor = GetIngredientDiversityFactor();
+
+        return baseOrderProbability * performanceFactor * timeFactor * dayFactor * diversityFactor;
     }
 
     private float GetTimeBuzzFactor(int hour)
@@ -70,5 +84,31 @@ public class OrderSpawner : MonoBehaviour
             DayOfWeek.Friday => 1.2f,
             _ => 1.0f
         };
+    }
+    private float GetIngredientDiversityFactor()
+    {
+        int count = IngredientStockManager.Instance.GetPurchasedIngredientCount();
+
+        if (count >= 20)
+            return 1.0f;  // 영향 없음
+        if (count >= 17)
+            return 0.95f;
+        if (count >= 14)
+            return 0.9f;
+        if (count >= 11)
+            return 0.85f;
+        if (count >= 8)
+            return 0.8f;
+        return 0.75f;  // 8개 미만은 가장 큰 패널티
+    }
+
+    public void StopSpawning()
+    {
+        CancelInvoke(nameof(TryOrder));
+    }
+    public void RestartSpawning()
+    {
+        CancelInvoke(nameof(TryOrder));  // 혹시 몰라 먼저 취소
+        InvokeRepeating(nameof(TryOrder), 0f, attemptInterval);
     }
 }

--- a/Tteokbokki/Assets/02.Script/RandomReceiptGenerator.cs
+++ b/Tteokbokki/Assets/02.Script/RandomReceiptGenerator.cs
@@ -164,6 +164,13 @@ public class RandomReceiptGenerator : MonoBehaviour
                 extras = GetRandomExtras(extraCount, extrasStock);
             }
 
+            var totalIngredients = CombinedIngredientManager.GetCombinedIngredients(MenuDatabase.Menus[menuName], extras);
+            if (!HasEnoughStock(totalIngredients))
+            {
+                Debug.Log("[취소] 재고 부족으로 영수증 생성 안됨");
+                return;
+            }
+
             newReceipt.AddOrder(menuName, extras);
         }
 
@@ -357,9 +364,10 @@ public class RandomReceiptGenerator : MonoBehaviour
     private Dictionary<string, int> GetAvailableExtras()
     {
         return IngredientDatabase.Ingredients.Keys
-        .Where(name => IngredientStockManager.Instance.GetStock(name) > 0)
-        .Where(name => !excludedExtras.Contains(name))   // ❗제외 항목 제거
-        .ToDictionary(name => name, name => IngredientStockManager.Instance.GetStock(name));
+            .Where(name =>
+                IngredientStockManager.Instance.HasPurchasedBefore(name) &&   // 최소 1회 구매
+                IngredientStockManager.Instance.GetStock(name) > 0 &&        // 재고도 있음
+                !excludedExtras.Contains(name))                              // 제외 재료도 필터
+            .ToDictionary(name => name, name => IngredientStockManager.Instance.GetStock(name));
     }
-
 }

--- a/Tteokbokki/Assets/02.Script/ReceiptLineItem.cs
+++ b/Tteokbokki/Assets/02.Script/ReceiptLineItem.cs
@@ -86,6 +86,7 @@ public class ReceiptLineItem : MonoBehaviour
         if (elapsed.TotalMinutes >= cookTimeSeconds / 60f)
         {
             //Debug.LogWarning($"[영수증 {receipt.OrderID}] 시간이 초과되어 삭제됩니다.");
+            ReceiptLineManager.Instance.RecordFailedReceipt(receipt);
             manager.RemoveReceipt(this);
             return;
         }


### PR DESCRIPTION
# Pull Request 제목
feat: 날짜 요일 EndOfDay StartOfDay 수정 #20

## 관련 이슈
Closes #20 

## 변경 사항 요약
- EndOfDay와 StartOfDay를 수정해서 날짜와 요일이 원활하게 넘어가도록 수정
- 운영시간 설정하고 마감 시스템 구현
- 재료를 한번은 주문했었는지에 따라서 재고를 일부러 채우지 않을 경우 영수증 감소 패널티 적용
- 영수증 생성 확률에 재료의 가짓수가 영향을 주도록 수정

## 테스트 방법
- [ ] 빌드가 정상적으로 되는지 확인
- [ ] 해당 기능이 예상대로 동작하는지 확인
- [ ] 기존 기능이 영향을 받지 않는지 확인

## 변경된 파일
- SampleScene.unity
- GameClock.cs
- GameManager.cs
- GameSaveManager.cs
- IngredientStockManager.cs
- StoveManager.cs
- OrderSpawner.cs
- RandomReceiptGenerator.cs
- ReceiptLineItem.cs

## 리뷰어에게
- 수정된 게 많습니다!

---

_이 PR은 기능 단위로 잘게 나뉜 작업 중 하나입니다. main/dev 브랜치에 병합 후, 관련 이슈는 자동으로 종료됩니다._
